### PR TITLE
[chore][repo] add CODEOWNERS for whole repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @yehudat


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` assigning the entire tree to `@yehudat`.
- Salvaged from the rebased `refactor/modernize-python-test-stack` branch (`9d68668`); the rest of that branch's content already landed on master via the prior PR, but this one commit was orphaned.

## Test plan
- [ ] CI green
- [ ] CODEOWNERS recognized by GitHub on this PR (review request auto-assigned)